### PR TITLE
Error Fix

### DIFF
--- a/return_values.txt
+++ b/return_values.txt
@@ -24,11 +24,13 @@ function RETURN_VALUES()
   simulador_sheet_backend.getRange("D15").setValue(real_weight);
   simulador_sheet_backend.getRange("D16").setValue(price);
   
+  Utilities.sleep(10000);
+  
   var capitals = simulador_sheet_backend.getRange(13, 7, 27).getValues();
   var interiors = simulador_sheet_backend.getRange(13, 8, 27).getValues();
   var freight_average_olist = simulador_sheet_backend.getRange("F8").getValue();
   var freight_average_correios = simulador_sheet_backend.getRange("I8").getValue();
-  var comparison = "correios é " + Math.round(((freight_average_correios / freight_average_olist) - 1) * 100) + " % mais caro que olist";
+  var comparison = "correios Ã© " + Math.round(((freight_average_correios / freight_average_olist) - 1) * 100) + "% mais caro que olist";
   
   simulador_sheet_simulator.getRange(14, 7, 27).setValues(capitals);
   simulador_sheet_simulator.getRange(14, 9, 27).setValues(interiors);


### PR DESCRIPTION
Adding a delay of 10000 miliseconds after setting the values to the backend spreadsheets, so the backend calculates everything during the 10 seconds and just when it is finished the script continues to get the values. This was needed to avoid an error that was appearing when the script tried to pull the values from the backend spreadsheet, but it still hasn't finished calculating the costs. Also removes the space between the % and the number it shows.